### PR TITLE
feat: Implemented the product comparison page for issue #58 for client repository for sellpoint-pp-ua project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1382,6 +1382,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1447,6 +1448,7 @@
       "integrity": "sha512-6sMvZePQrnZH2/cJkwRpkT7DxoAWh+g6+GFRK6bV3YQo7ogi3SX5rgF6099r5Q53Ma5qeT7LGmOmuIutF4t3lA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.35.0",
         "@typescript-eslint/types": "8.35.0",
@@ -1963,6 +1965,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2891,6 +2894,7 @@
       "integrity": "sha512-iN/SiPxmQu6EVkf+m1qpBxzUhE12YqFLOSySuOyVLJLEF9nzTf+h/1AJYc1JWzCnktggeNrjvQGLngDzXirU6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3065,6 +3069,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5848,6 +5853,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5857,6 +5863,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -6600,7 +6607,8 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
       "integrity": "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.2.2",
@@ -6668,6 +6676,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6826,6 +6835,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -1,0 +1,349 @@
+'use client'
+
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
+import Header from '@/components/layout/Header'
+import SiteFooter from '@/components/layout/SiteFooter'
+import Image from 'next/image'
+import Link from 'next/link'
+import { ChevronsDownUp, ChevronsUpDown } from 'lucide-react'
+import { useCompare } from '@/components/compare/CompareDrawerProvider'
+
+type AnyRecord = Record<string, any>
+type EnrichedProduct = { id: string; product?: AnyRecord | null; imageUrl?: string | null }
+
+export default function ComparePage() {
+  const search = useSearchParams()
+  const { ids: stateIds, add, max } = useCompare()
+  const [ids, setIds] = useState<string[]>([])
+  const [loading, setLoading] = useState(false)
+  const [items, setItems] = useState<EnrichedProduct[]>([])
+  const [showDiffOnly, setShowDiffOnly] = useState(false)
+  const [featureQuery, setFeatureQuery] = useState('')
+  const [highlightKey, setHighlightKey] = useState<string | null>(null)
+  const scrollerRef = useRef<HTMLDivElement | null>(null)
+  const rowRefs = useRef<Map<string, HTMLTableRowElement>>(new Map())
+  const [colWidth, setColWidth] = useState<number>(280)
+  const [compact, setCompact] = useState(false)
+
+  // Merge URL ids with state ids on mount
+  useEffect(() => {
+    const fromUrl = (search.get('ids') || '')
+      .split(',')
+      .map((x) => x.trim())
+      .filter(Boolean)
+    const merged = Array.from(new Set([...fromUrl, ...stateIds])).slice(0, max)
+    setIds(merged)
+    // also reflect into state (so drawer shows the same selection)
+    for (const id of merged) add(id)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Fetch products + media
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      if (ids.length === 0) { setItems([]); return }
+      setLoading(true)
+      try {
+        const enriched: EnrichedProduct[] = await Promise.all(
+          ids.map(async (id) => {
+            try {
+              const [pRes, mRes] = await Promise.all([
+                fetch(`https://api.sellpoint.pp.ua/api/Product/get-by-id/${id}`, { cache: 'no-store' }),
+                fetch(`https://api.sellpoint.pp.ua/api/ProductMedia/by-product-id/${id}`, { cache: 'no-store' }),
+              ])
+              const product = pRes.ok ? await pRes.json() : null
+              let imageUrl: string | null = null
+              if (mRes.ok) {
+                const media: any[] = await mRes.json()
+                const first = (Array.isArray(media) ? media : []).sort((a, b) => (a?.order || 0) - (b?.order || 0))[0]
+                imageUrl = first?.files?.compressedUrl || first?.files?.sourceUrl || null
+              }
+              return { id, product, imageUrl }
+            } catch {
+              return { id }
+            }
+          })
+        )
+        if (!cancelled) setItems(enriched)
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => { cancelled = true }
+  }, [ids])
+
+  // Compute dynamic column width so up to 4 products fill available space nicely
+  useEffect(() => {
+    const compute = () => {
+      if (!scrollerRef.current) return
+      const el = scrollerRef.current
+      const total = el.clientWidth || 0
+      if (!total) return
+      const FIRST_COL = 256 // w-64
+      const PADDING = 16
+      const cols = Math.max(1, Math.min(4, items.length || 1))
+      const raw = Math.floor((total - FIRST_COL - PADDING) / cols)
+      const clamped = Math.max(220, Math.min(360, raw))
+      setColWidth(clamped)
+    }
+    // Run initially and on resize
+    compute()
+    let ro: ResizeObserver | null = null
+    try {
+      ro = new ResizeObserver(() => compute())
+      if (scrollerRef.current) ro.observe(scrollerRef.current)
+    } catch {}
+    window.addEventListener('resize', compute)
+    return () => {
+      window.removeEventListener('resize', compute)
+      if (ro && scrollerRef.current) ro.disconnect()
+    }
+  }, [items.length])
+
+  // Build spec matrix: base + flattened features
+  const matrix = useMemo(() => {
+    const rows: { key: string; label: string; group?: string; values: Map<string, string> }[] = []
+    const rowMap = new Map<string, number>()
+    const ensureRow = (group: string | undefined, label: string, key: string) => {
+      const compound = `${group || 'Основне'}::${key}`
+      if (!rowMap.has(compound)) {
+        rowMap.set(compound, rows.length)
+        rows.push({ key: compound, label, group, values: new Map() })
+      }
+      return rowMap.get(compound)!
+    }
+
+    const baseDefs: { label: string; key: string; value: (p: AnyRecord) => string }[] = [
+      { label: 'Ціна', key: 'price', value: (p) => String(Math.round(p?.finalPrice ?? p?.discountPrice ?? p?.price ?? 0) || '—') },
+      { label: 'Знижка', key: 'discount', value: (p) => p?.hasDiscount ? `${Math.round(p?.discountPercentage ?? 0)}%` : '—' },
+      { label: 'Наявність', key: 'availability', value: (p) => {
+        const qs = p?.quantityStatus
+        if (qs === 3) return 'Немає в наявності'
+        if (qs === 2) return 'Закінчується'
+        return 'В наявності'
+      } },
+    ]
+
+    for (const ep of items) {
+      const p = ep.product || {}
+      const pid = String(p?.id || ep.id)
+      for (const def of baseDefs) {
+        const idx = ensureRow('Основне', def.label, def.key)
+        rows[idx].values.set(pid, def.value(p))
+      }
+    }
+
+    for (const ep of items) {
+      const p = ep.product || {}
+      const pid = String(p?.id || ep.id)
+      const groups = Array.isArray(p?.features) ? p.features : []
+      for (const g of groups) {
+        const groupName = typeof g?.category === 'string' ? g.category : 'Характеристики'
+        const feats = g?.features && typeof g.features === 'object' ? (g.features as AnyRecord) : {}
+        for (const rawKey of Object.keys(feats)) {
+          const f = feats[rawKey]
+          const label = rawKey
+          const display = f && typeof f === 'object' && 'value' in f ? String((f as AnyRecord).value ?? '—') : '—'
+          const idx = ensureRow(groupName, label, `${groupName}:${label}`)
+          rows[idx].values.set(pid, display)
+        }
+      }
+    }
+
+    const filtered = showDiffOnly
+      ? rows.filter((r) => {
+          const vals = ids.map((id) => r.values.get(String(id)) ?? '—')
+          return vals.some((v, i, arr) => v !== arr[0])
+        })
+      : rows
+
+    const byGroup = new Map<string, { group: string; items: typeof filtered }>()
+    for (const r of filtered) {
+      const g = r.group || 'Основне'
+      if (!byGroup.has(g)) byGroup.set(g, { group: g, items: [] as any })
+      ;(byGroup.get(g)!.items as any).push(r)
+    }
+    return { groups: Array.from(byGroup.values()) }
+  }, [items, showDiffOnly, ids])
+
+  const handleFindFeature = (e?: React.FormEvent) => {
+    if (e) e.preventDefault()
+    const q = featureQuery.trim().toLowerCase()
+    if (!q) return
+    for (const group of matrix.groups) {
+      for (const r of group.items) {
+        const label = r.label.toLowerCase()
+        const grp = (r.group || '').toLowerCase()
+        if (label.includes(q) || grp.includes(q)) {
+          setHighlightKey(r.key)
+          const tr = rowRefs.current.get(r.key)
+          const scroller = scrollerRef.current
+          if (tr && scroller) {
+            const trRect = tr.getBoundingClientRect()
+            const scRect = scroller.getBoundingClientRect()
+            const current = scroller.scrollTop
+            const deltaTop = trRect.top - scRect.top
+            const centerOffset = (scroller.clientHeight / 2) - (tr.clientHeight / 2)
+            let target = current + deltaTop - centerOffset
+            const max = scroller.scrollHeight - scroller.clientHeight
+            if (target < 0) target = 0
+            if (target > max) target = max
+            scroller.scrollTo({ top: target, behavior: 'smooth' })
+          }
+          setTimeout(() => setHighlightKey(null), 1200)
+          return
+        }
+      }
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Header />
+      <main className="mx-auto max-w-[1500px] px-4 py-6">
+        <h1 className="text-2xl font-bold text-gray-900 mb-4">Порівняння товарів</h1>
+
+        {ids.length < 2 && (
+          <div className="mb-4 rounded-lg bg-yellow-50 p-3 text-sm text-yellow-800 border border-yellow-200">Додайте принаймні 2 товари для порівняння.</div>
+        )}
+
+        {/* Toolbar */}
+        <div className="mb-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div className="flex items-center gap-4">
+            <label className="inline-flex items-center gap-2 text-sm text-gray-700">
+              <input
+                type="checkbox"
+                className="h-4 w-4"
+                checked={showDiffOnly}
+                onChange={(e) => setShowDiffOnly(e.target.checked)}
+              />
+              Показати відмінності
+            </label>
+          </div>
+          <form onSubmit={handleFindFeature} className="flex items-center gap-2">
+            <input
+              type="text"
+              placeholder="Знайти характеристику…"
+              value={featureQuery}
+              onChange={(e) => setFeatureQuery(e.target.value)}
+              className="w-[280px] rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-[#4563d1]/30 focus:border-[#4563d1]"
+            />
+            <button type="submit" className="rounded-lg bg-[#4563d1] px-3 py-2 text-sm text-white hover:bg-[#364ea8]">Знайти</button>
+          </form>
+        </div>
+
+        {/* Table */}
+        <div ref={scrollerRef} className="overflow-auto rounded-xl border border-gray-200 bg-white shadow-sm max-h-[70vh]">
+          {/* Sticky product header */}
+          <table className="w-auto text-sm">
+            <thead className="sticky top-0 z-20 bg-white/95 backdrop-blur text-left shadow-[0_1px_0_rgba(0,0,0,0.06)]">
+              <tr>
+                <th className="sticky left-0 z-30 bg-white/95 px-3 py-3 w-64 font-semibold text-gray-700 text-center relative">
+                  <button
+                    type="button"
+                    aria-label={compact ? 'Розгорнути шапку' : 'Згорнути шапку'}
+                    onClick={() => setCompact((v) => !v)}
+                    className="absolute left-2 top-2 rounded-md p-1.5 text-gray-600 hover:bg-gray-100 transition-colors"
+                  >
+                    {compact ? (
+                      <ChevronsUpDown className="h-5 w-5" />
+                    ) : (
+                      <ChevronsDownUp className="h-5 w-5" />
+                    )}
+                  </button>
+                  Характеристика
+                </th>
+                {items.map((it, idx) => {
+                  const p = it.product
+                  const price = Math.round(p?.finalPrice ?? p?.discountPrice ?? p?.price ?? 0)
+                  const old = p?.hasDiscount && p?.price && p?.price > (p?.finalPrice ?? p?.discountPrice ?? p?.price)
+                  return (
+                    <th
+                      key={it.id}
+                      className={`px-5 py-3 align-top ${idx > 0 ? 'border-l border-gray-200' : ''}`}
+                      style={{ width: colWidth, maxWidth: colWidth }}
+                    >
+                      <div className="flex flex-col items-start gap-2">
+                        <div className={`relative w-20 overflow-hidden rounded-md border border-gray-200 bg-gray-50 transition-all duration-300 ${compact ? 'h-0 opacity-0 -translate-y-1' : 'h-20 opacity-100 translate-y-0'}`}>
+                          {it.imageUrl ? (
+                            <Image src={it.imageUrl} alt={p?.name || ''} fill className="object-contain" />
+                          ) : null}
+                        </div>
+                        <div className="min-w-0">
+                          <Link href={`/product/${it.id}`} className={`block font-semibold text-gray-900 leading-snug break-words whitespace-normal transition-all duration-300 ${compact ? 'text-sm' : 'text-base'}`}>
+                            {p?.name || 'Товар'}
+                          </Link>
+                          <div className={`text-gray-700 transition-all duration-300 ${compact ? 'max-h-0 opacity-0 -translate-y-1 overflow-hidden' : 'mt-1 max-h-10 opacity-100 translate-y-0'}`}>
+                            <span className={`font-bold text-[#E53935] ${compact ? 'text-lg' : 'text-xl'}`}>{price ? `${price} грн` : '—'}</span>
+                            {!compact && old && (
+                              <span className="ml-2 text-sm text-gray-400 line-through">{Math.round(p!.price)} грн</span>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    </th>
+                  )
+                })}
+              </tr>
+            </thead>
+            <tbody>
+              {matrix.groups.map((g) => (
+                <React.Fragment key={g.group}>
+                  <tr>
+                    <td colSpan={items.length + 1} className="bg-gray-100 px-3 py-2 font-semibold text-gray-800 sticky left-0 z-10">{g.group}</td>
+                  </tr>
+                  {g.items.map((r) => (
+                    <tr
+                      key={r.key}
+                      ref={(el) => { if (el) rowRefs.current.set(r.key, el) }}
+                      className={`odd:bg-white even:bg-gray-50`}
+                    >
+                      <td className={`sticky left-0 z-10 bg-inherit px-4 py-3 text-gray-700 font-medium ${highlightKey === r.key ? 'compare-highlight-cell' : ''}`}>
+                        <span className={highlightKey === r.key ? 'compare-highlight-text' : ''} style={{ ['--compareBaseColor' as any]: '#374151' }}>
+                          {r.label}
+                        </span>
+                      </td>
+                      {items.map((it, idx) => (
+                        <td
+                          key={it.id}
+                          className={`px-5 py-3 text-gray-800 align-top ${idx > 0 ? 'border-l border-gray-200' : ''} break-words whitespace-normal ${highlightKey === r.key ? 'compare-highlight-cell' : ''}`}
+                          style={{ width: colWidth, maxWidth: colWidth }}
+                        >
+                          <span className={highlightKey === r.key ? 'compare-highlight-text' : ''} style={{ ['--compareBaseColor' as any]: '#1f2937' }}>
+                            {r.values.get(String(it.product?.id || it.id)) ?? '—'}
+                          </span>
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </React.Fragment>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {loading && (
+          <div className="mt-3 text-sm text-gray-600">Завантаження…</div>
+        )}
+      </main>
+      <SiteFooter />
+      {/* Highlight animations for compare feature */}
+      <style jsx global>{`
+        @keyframes compareGlow {
+          0% { box-shadow: 0 0 0 2px rgba(69,99,209,0.95) inset, 0 0 14px rgba(69,99,209,0.55); }
+          60% { box-shadow: 0 0 0 2px rgba(69,99,209,0.55) inset, 0 0 8px rgba(69,99,209,0.35); }
+          100% { box-shadow: 0 0 0 0 rgba(69,99,209,0) inset, 0 0 0 rgba(69,99,209,0); }
+        }
+        @keyframes compareText {
+          0% { color: #4563d1; text-shadow: 0 0 6px rgba(69,99,209,0.45); }
+          60% { color: #4563d1; text-shadow: 0 0 4px rgba(69,99,209,0.3); }
+          100% { color: var(--compareBaseColor, inherit); text-shadow: none; }
+        }
+        .compare-highlight-cell { position: relative; border-radius: 6px; animation: compareGlow 1600ms ease both; }
+        .compare-highlight-text { animation: compareText 1100ms ease both; }
+      `}</style>
+    </div>
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import CartDrawerProvider from "@/components/cart/CartDrawerProvider";
+import CompareDrawerProvider from "@/components/compare/CompareDrawerProvider";
 import FavoritesProvider from "@/components/favorites/FavoritesProvider";
 import NotificationsDrawerProvider from "@/components/notifications/NotificationsDrawerProvider";
 
@@ -22,11 +23,13 @@ export default function RootLayout({
       <body className={inter.className}>
         <div className="min-h-screen bg-gray-50">
           <CartDrawerProvider>
-            <NotificationsDrawerProvider>
-              <FavoritesProvider>
-                {children}
-              </FavoritesProvider>
-            </NotificationsDrawerProvider>
+            <CompareDrawerProvider>
+              <NotificationsDrawerProvider>
+                <FavoritesProvider>
+                  {children}
+                </FavoritesProvider>
+              </NotificationsDrawerProvider>
+            </CompareDrawerProvider>
           </CartDrawerProvider>
         </div>
       </body>

--- a/src/components/compare/CompareButton.tsx
+++ b/src/components/compare/CompareButton.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import React from 'react'
+import { useCompare } from './CompareDrawerProvider'
+
+export default function CompareButton({ productId, className = '' }: { productId: string; className?: string }) {
+  const { has, toggle, openCompare, count, max } = useCompare()
+  const inCompare = has(productId)
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        toggle(productId)
+        // If first item was added, open the drawer to make it visible
+        setTimeout(() => {
+          if (!inCompare && count + 1 > 0) openCompare()
+        }, 0)
+      }}
+      className={`inline-flex items-center justify-center rounded-xl border px-3 py-1.5 text-sm ${
+        inCompare ? 'border-green-300 bg-green-50 text-green-800' : 'border-gray-300 text-gray-700 hover:bg-gray-50'
+      } ${className}`}
+      aria-pressed={inCompare}
+      aria-label={inCompare ? 'Видалити з порівняння' : 'Додати до порівняння'}
+      disabled={!inCompare && count >= max}
+    >
+      {inCompare ? 'У порівнянні' : 'Додати до порівняння'}
+    </button>
+  )
+}

--- a/src/components/compare/CompareDrawerProvider.tsx
+++ b/src/components/compare/CompareDrawerProvider.tsx
@@ -1,0 +1,305 @@
+'use client'
+
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import Image from 'next/image'
+import { X, Trash2 } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { useCompareState } from '@/hooks/useCompare'
+
+type ProductBrief = {
+  id: string
+  name: string
+  price?: number
+  discountPrice?: number
+  hasDiscount?: boolean
+}
+
+type Enriched = {
+  id: string
+  product?: ProductBrief
+  imageUrl?: string | null
+  leafCategoryId?: string | null
+  leafCategoryName?: string | null
+}
+
+type Ctx = {
+  isOpen: boolean
+  openCompare: () => void
+  closeCompare: () => void
+  ids: string[]
+  add: (id: string) => void
+  remove: (id: string) => void
+  toggle: (id: string) => void
+  clear: () => void
+  has: (id: string) => boolean
+  count: number
+  max: number
+}
+
+const CompareContext = createContext<Ctx | undefined>(undefined)
+
+export function useCompare() {
+  const ctx = useContext(CompareContext)
+  if (!ctx) throw new Error('useCompare must be used within CompareDrawerProvider')
+  return ctx
+}
+
+export default function CompareDrawerProvider({ children }: { children: React.ReactNode }) {
+  const router = useRouter()
+  const state = useCompareState()
+  const [isOpen, setIsOpen] = useState(false)
+  const [items, setItems] = useState<Enriched[]>([])
+  const [allowedLeafId, setAllowedLeafId] = useState<string | null>(null)
+
+  const openCompare = useCallback(() => setIsOpen(true), [])
+  const closeCompare = useCallback(() => setIsOpen(false), [])
+
+  // Fetch minimal product info + first media image for drawer thumbnails
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const enriched: Enriched[] = await Promise.all(
+          state.ids.map(async (id) => {
+            try {
+              const [pRes, mRes] = await Promise.all([
+                fetch(`https://api.sellpoint.pp.ua/api/Product/get-by-id/${id}`, { cache: 'no-store' }),
+                fetch(`https://api.sellpoint.pp.ua/api/ProductMedia/by-product-id/${id}`, { cache: 'no-store' }),
+              ])
+              const product: any = pRes.ok ? await pRes.json() : null
+              let imageUrl: string | null = null
+              if (mRes.ok) {
+                const media: any[] = await mRes.json()
+                const first = (Array.isArray(media) ? media : []).sort((a, b) => (a?.order || 0) - (b?.order || 0))[0]
+                imageUrl = first?.files?.compressedUrl || first?.files?.sourceUrl || null
+              }
+              // Leaf category id and name
+              // Use the FIRST element of categoryPath as the deepest (leaf) category per API contract
+              const leafCategoryId: string | null = Array.isArray(product?.categoryPath) && product.categoryPath.length > 0
+                ? String(product.categoryPath[0])
+                : null
+              let leafCategoryName: string | null = null
+              if (leafCategoryId) {
+                try {
+                  const cRes = await fetch(`/api/categories/${encodeURIComponent(leafCategoryId)}`, { cache: 'no-store' })
+                  if (cRes.ok) {
+                    const c = await cRes.json()
+                    leafCategoryName = typeof c?.name === 'string' ? c.name : null
+                  }
+                } catch {}
+              }
+              return { id, product: product || undefined, imageUrl, leafCategoryId, leafCategoryName }
+            } catch {
+              return { id }
+            }
+          })
+        )
+        if (!cancelled) setItems(enriched)
+      } catch {
+        if (!cancelled) setItems([])
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [state.ids])
+
+  // Track allowed leaf category based on first item
+  useEffect(() => {
+    const first = items.find((it) => it.product)
+    const leaf = first?.leafCategoryId || null
+    setAllowedLeafId(leaf)
+  }, [items])
+
+  // Lock scroll behavior identical to CartDrawerProvider
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+    const body = document.body
+    const prevPosition = body.style.position
+    const prevTop = body.style.top
+    const prevLeft = body.style.left
+    const prevRight = body.style.right
+    const prevWidth = body.style.width
+    const scrollY = window.scrollY
+    if (isOpen) {
+      body.classList.add('lock-scroll')
+      body.style.top = `-${scrollY}px`
+    } else {
+      body.classList.remove('lock-scroll')
+      body.style.position = prevPosition
+      body.style.top = ''
+      body.style.left = prevLeft
+      body.style.right = prevRight
+      body.style.width = prevWidth
+      window.scrollTo(0, scrollY)
+    }
+    return () => {
+      body.classList.remove('lock-scroll')
+      body.style.position = prevPosition
+      body.style.top = ''
+      body.style.left = prevLeft
+      body.style.right = prevRight
+      body.style.width = prevWidth
+      window.scrollTo(0, scrollY)
+    }
+  }, [isOpen])
+
+  // Close on ESC
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeCompare()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [closeCompare])
+
+  // Helper to fetch leaf category id of a product by id
+  const fetchLeafCategoryId = useCallback(async (productId: string): Promise<string | null> => {
+    try {
+      const res = await fetch(`https://api.sellpoint.pp.ua/api/Product/get-by-id/${productId}`, { cache: 'no-store' })
+      if (!res.ok) return null
+      const p: any = await res.json()
+      const path: any[] = Array.isArray(p?.categoryPath) ? p.categoryPath : []
+      // Per API, the FIRST element is the leaf-most category id
+      return path.length > 0 ? String(path[0]) : null
+    } catch {
+      return null
+    }
+  }, [])
+
+  // Enforced add/toggle respecting category constraint
+  const addEnforced = useCallback(async (id: string) => {
+    if (state.has(id)) return
+    const leaf = await fetchLeafCategoryId(id)
+    if (!allowedLeafId || !leaf || leaf === allowedLeafId) {
+      state.add(id)
+      if (!allowedLeafId && leaf) setAllowedLeafId(leaf)
+    } else {
+      // ignore addition from other categories
+    }
+  }, [state, allowedLeafId, fetchLeafCategoryId])
+
+  const toggleEnforced = useCallback(async (id: string) => {
+    if (state.has(id)) {
+      state.toggle(id)
+      return
+    }
+    await addEnforced(id)
+  }, [state, addEnforced])
+
+  const clearAll = useCallback(() => {
+    state.clear()
+    setAllowedLeafId(null)
+  }, [state])
+
+  const ctx = useMemo<Ctx>(() => ({
+    isOpen,
+    openCompare,
+    closeCompare,
+    ids: state.ids,
+    add: (id: string) => { void addEnforced(id) },
+    remove: (id: string) => { state.remove(id) },
+    toggle: (id: string) => { void toggleEnforced(id) },
+    clear: clearAll,
+    has: state.has,
+    count: state.count,
+    max: state.max,
+  }), [isOpen, openCompare, closeCompare, state, addEnforced, toggleEnforced, clearAll])
+
+  return (
+    <CompareContext.Provider value={ctx}>
+      {children}
+
+      {/* Overlay (match CartDrawerProvider) */}
+      <div
+        aria-hidden
+        onClick={closeCompare}
+        className={`fixed inset-0 z-[90] bg-gray-700/30 transition-opacity duration-300 ${
+          isOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
+        }`}
+      />
+
+      {/* Drawer (match CartDrawerProvider) */}
+      <aside
+        role="dialog"
+        aria-modal="true"
+        className={`fixed right-0 top-0 z-[95] h-full w-[400px] max-w-[92vw] bg-white shadow-2xl rounded-l-2xl transition-transform duration-300 ease-out ${
+          isOpen ? 'translate-x-0' : 'translate-x-full'
+        }`}
+      >
+        {/* Header */}
+        <div className="relative flex items-center justify-center p-3">
+          <h2 className="text-[18px] font-bold text-gray-900">Порівняння</h2>
+          <button
+            aria-label="Закрити"
+            onClick={closeCompare}
+            className="absolute right-2 top-1/2 -translate-y-1/2 p-2 rounded-lg hover:bg-gray-100"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Empty state */}
+        {state.count === 0 ? (
+          <div className="flex h-[calc(100%-52px)] flex-col items-center bg-gray-100 justify-center px-6 text-center text-gray-700">
+            <div className="text-[16px] text-gray-700">Додайте товари для порівняння</div>
+          </div>
+        ) : (
+          <div className="flex h-[calc(100%-52px)] flex-col bg-gray-100">
+            <div className="mt-2 flex-1 overflow-y-auto px-3 pb-3">
+              {items.map((it) => (
+                <div key={it.id} className="mb-2 rounded-xl bg-white p-3 shadow-sm">
+                  <div className="flex items-start gap-3">
+                    <div className="relative h-16 w-16 flex-shrink-0 overflow-hidden rounded-lg border border-gray-200 bg-white">
+                      {it.imageUrl ? (
+                        <Image src={it.imageUrl} alt={it.product?.name || ''} fill className="object-contain" />
+                      ) : null}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-start gap-2">
+                        <Link href={`/product/${it.id}`} className="line-clamp-2 text-sm font-medium text-gray-900 hover:underline">
+                          {it.product?.name || 'Товар'}
+                        </Link>
+                        <button
+                          onClick={() => state.remove(it.id)}
+                          className="ml-auto rounded-lg p-1 text-gray-500 hover:bg-gray-100"
+                          aria-label="Видалити з порівняння"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </button>
+                      </div>
+                      {it.leafCategoryId && (
+                        <div className="mt-1 text-xs text-gray-600">
+                          Категорія:{' '}
+                          <Link href={`/category/${it.leafCategoryId}`} className="text-[#4563d1] hover:underline">
+                            {it.leafCategoryName || 'Категорія'}
+                          </Link>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {/* Footer */}
+            <div className="border-t border-gray-200 bg-white p-3 shadow-[0_-2px_8px_rgba(0,0,0,0.06)]">
+              <div className="flex items-center justify-between px-1 text-sm text-gray-700">
+                <span>Обрано: {state.count}/{state.max}</span>
+                  <button onClick={clearAll} className="text-sm text-gray-600 hover:underline">Очистити</button>
+              </div>
+              <button
+                onClick={() => { closeCompare(); router.push(`/compare?ids=${encodeURIComponent(state.ids.join(','))}`) }}
+                className="mt-2 w-full rounded-xl bg-[#4563d1] py-2.5 text-sm text-white hover:bg-[#364ea8] disabled:opacity-50"
+                disabled={state.count < 2}
+              >
+                Порівняти всі
+              </button>
+            </div>
+          </div>
+        )}
+      </aside>
+    </CompareContext.Provider>
+  )
+}

--- a/src/components/features/ApiProductCard.tsx
+++ b/src/components/features/ApiProductCard.tsx
@@ -3,10 +3,11 @@
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
-import { Heart, ShoppingCart, Star } from 'lucide-react'
+import { Heart, ShoppingCart, Star, GitCompareArrows } from 'lucide-react'
 import { useCartDrawer } from '@/components/cart/CartDrawerProvider'
 import { useAuth } from '@/hooks/useAuth'
 import { useFavorites } from '@/components/favorites/FavoritesProvider'
+import { useCompare } from '@/components/compare/CompareDrawerProvider'
 
 interface ApiProductCardProps {
   id: string;
@@ -39,6 +40,7 @@ export default function ApiProductCard({
   const { addToCart, isInCart, openCart } = useCartDrawer()
   const { isAuthenticated } = useAuth()
   const { lists, isInFavorites, toggleFavorite, openPicker, picker, productToListId, ui } = useFavorites()
+  const { has, toggle: toggleCompare, openCompare } = useCompare()
 
   const title = name || 'Без назви'
   const normalizedStatus = typeof quantityStatus === 'string' ? quantityStatus.toLowerCase() : ''
@@ -187,6 +189,19 @@ export default function ApiProductCard({
         }}
       >
         <Heart className={`h-5 w-5 ${inFav ? 'fill-current' : ''}`} />
+      </button>
+      {/* Compare toggle button */}
+      <button
+        className={`absolute right-14 hover:cursor-pointer top-4 z-10 rounded-full p-1.5 ${has(id) ? 'bg-[#4563d1]/10 text-[#4563d1]' : 'bg-white text-gray-400'} transition-colors hover:text-[#4563d1]`}
+        aria-label={has(id) ? 'Видалити з порівняння' : 'Додати до порівняння'}
+        onClick={(e) => {
+          e.preventDefault()
+          const wasIn = has(id)
+          toggleCompare(id)
+          if (!wasIn) openCompare()
+        }}
+      >
+        <GitCompareArrows className="h-5 w-5" />
       </button>
       
       <Link href={`/product/${id}`}>

--- a/src/components/features/ProductPageTemplate.tsx
+++ b/src/components/features/ProductPageTemplate.tsx
@@ -6,9 +6,10 @@ import SiteFooter from '@/components/layout/SiteFooter'
 import ApiProductCard from '@/components/features/ApiProductCard'
 import Image from 'next/image'
 import Link from 'next/link'
-import { Star, Truck, Package, CreditCard, ShieldCheck, Store, ChevronRight, ChevronLeft } from 'lucide-react'
+import { Star, Truck, Package, CreditCard, ShieldCheck, Store, ChevronRight, ChevronLeft, GitCompareArrows } from 'lucide-react'
 import { useCartDrawer } from '@/components/cart/CartDrawerProvider'
 import { useRouter } from 'next/navigation'
+import { useCompare } from '@/components/compare/CompareDrawerProvider'
 
 
 type MediaItem = { url?: string; secondaryUrl?: string; order?: number; type?: 'image' | 'video' }
@@ -70,6 +71,7 @@ export default function ProductPageTemplate({ productId }: Props) {
   const [loadingViewed, setLoadingViewed] = useState(false)
   const [loadingSimilarOther, setLoadingSimilarOther] = useState(false)
   const [productImages, setProductImages] = useState<Record<string, string>>({})
+  const { has: inCompare, toggle: toggleCompare, openCompare } = useCompare()
 
   useEffect(() => {
     let cancelled = false
@@ -909,6 +911,15 @@ export default function ProductPageTemplate({ productId }: Props) {
                   className="rounded-full border hover:cursor-pointer border-[#4563d1] px-1 py-2 text-sm border-2 text-[#4563d1] hover:bg-[#4563d1]/5"
                 >
                   Купити зараз
+                </button>
+              </div>
+              <div className="mt-3">
+                <button
+                  onClick={() => { const was = inCompare(productId); toggleCompare(productId); if (!was) openCompare() }}
+                  className={`inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm ${inCompare(productId) ? 'border-[#4563d1] text-[#4563d1] bg-white' : 'border-gray-300 text-gray-700 hover:border-[#4563d1] hover:text-[#4563d1]'}`}
+                >
+                  <GitCompareArrows className="h-4 w-4" />
+                  {inCompare(productId) ? 'У порівнянні' : 'Додати до порівняння'}
                 </button>
               </div>
             </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,13 +1,14 @@
 'use client'
 
 import { useState, useEffect, useRef } from 'react'
-import { Search, User, Bell, Heart, ShieldUser, ShoppingCart, Ambulance } from 'lucide-react'
+import { Search, User, Bell, Heart, ShieldUser, ShoppingCart, Ambulance, GitCompareArrows } from 'lucide-react'
 import Link from 'next/link'
 import AnimatedLogo from '@/components/shared/AnimatedLogo'
 import { useRouter } from 'next/navigation'
 import { useAuth } from '@/hooks/useAuth'
 import { useCartDrawer } from '@/components/cart/CartDrawerProvider'
 import { useNotifications } from '@/components/notifications/NotificationsDrawerProvider'
+import { useCompare } from '@/components/compare/CompareDrawerProvider'
 
 type CategorySearchResult = {
   id: string;
@@ -93,6 +94,7 @@ export default function Header() {
   const { isAuthenticated, logout } = useAuth()
   const { openCart, cartCount } = useCartDrawer()
   const { open: openNotifications, unreadCount } = useNotifications()
+  const { isOpen: compareOpen, openCompare, count: compareCount } = useCompare()
   const [isAdmin, setIsAdmin] = useState(false)
 
   useEffect(() => {
@@ -410,6 +412,16 @@ export default function Header() {
               <span className="hidden text-[12px] xl:block">Відстеження</span>
             </Link>
           )}
+          {/* Compare Drawer Button */}
+          <button onClick={() => { openCompare() }} className="relative hover:cursor-pointer flex flex-col items-center text-gray-700 hover:text-[#4563d1]">
+            <GitCompareArrows className="h-6 w-6" />
+            {compareCount > 0 && (
+              <span className="absolute -right-2 -top-1 inline-flex h-5 min-w-[20px] items-center justify-center rounded-full bg-blue-600 px-1 text-[11px] font-semibold text-white">
+                {compareCount}
+              </span>
+            )}
+            <span className="hidden text-[12px] xl:block">Порівняння</span>
+          </button>
           <button onClick={() => {
             openCart()
           }} className="relative hover:cursor-pointer flex flex-col items-center text-gray-700 hover:text-[#4563d1]">

--- a/src/hooks/useCompare.ts
+++ b/src/hooks/useCompare.ts
@@ -1,0 +1,66 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+const STORAGE_KEY = 'compare_product_ids'
+const MAX_COMPARE = 4
+
+export function useCompareState() {
+  const [ids, setIds] = useState<string[]>([])
+
+  // Load from localStorage once on mount
+  useEffect(() => {
+    try {
+      if (typeof window === 'undefined') return
+      const raw = localStorage.getItem(STORAGE_KEY)
+      if (!raw) return
+      const parsed = JSON.parse(raw)
+      if (Array.isArray(parsed)) {
+        const onlyStrings = parsed.filter((x) => typeof x === 'string') as string[]
+        setIds(Array.from(new Set(onlyStrings)).slice(0, MAX_COMPARE))
+      }
+    } catch {}
+  }, [])
+
+  // Persist on change
+  useEffect(() => {
+    try {
+      if (typeof window === 'undefined') return
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(ids))
+    } catch {}
+  }, [ids])
+
+  const has = useCallback((id: string) => ids.includes(id), [ids])
+
+  const add = useCallback((id: string) => {
+    setIds((prev) => {
+      if (!id) return prev
+      if (prev.includes(id)) return prev
+      if (prev.length >= MAX_COMPARE) return prev
+      return [...prev, id]
+    })
+  }, [])
+
+  const remove = useCallback((id: string) => {
+    setIds((prev) => prev.filter((x) => x !== id))
+  }, [])
+
+  const toggle = useCallback((id: string) => {
+    setIds((prev) => {
+      if (prev.includes(id)) return prev.filter((x) => x !== id)
+      if (prev.length >= MAX_COMPARE) return prev
+      return [...prev, id]
+    })
+  }, [])
+
+  const clear = useCallback(() => setIds([]), [])
+
+  const count = ids.length
+
+  return useMemo(
+    () => ({ ids, count, add, remove, toggle, clear, has, max: MAX_COMPARE }),
+    [ids, count, add, remove, toggle, clear, has]
+  )
+}
+
+export type UseCompareState = ReturnType<typeof useCompareState>


### PR DESCRIPTION
Closes #58

According to the Product Comparison Issue description, I've implemented:

1. A **Compare drawer** (same look/UX as the cart) with a header icon (left of the cart). Users can add up to 4 products, persisted in localStorage. The drawer enforces same leaf subcategory only (e.g., only laptops with laptops), shows product names as links to product pages, and displays “Category: <name>” with a link to the category.

2. The **** loads product details and media, then renders a styled side-by-side table with sticky header/first column, vertical separators, and responsive fixed column widths. Header cells show the image (left) and product title (link) + price (right), with a compact/expand toggle (prices hidden in compact).

3. UX features: “Show differences only” filter, feature search that scrolls the matched row into view (centered) and highlights all cells smoothly, and shareable URL via /compare?ids=… .

<img width="1605" height="918" alt="image" src="https://github.com/user-attachments/assets/9bb63492-f61e-4de9-9aa0-42a164e22ca1" />

Here is a link for a video showcase on my google drive that show how the implementation looks like: [Video](https://drive.google.com/file/d/1HiJljZ_wrLUFiuR5rNOf8LQMMxgLKOji/view?usp=sharing)
